### PR TITLE
feat: add selectable llm providers and dockerized cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ WORKDIR /workspace
 
 COPY requirements.txt .
 RUN apt-get update \
- && apt-get install -y --no-install-recommends build-essential libjpeg-dev zlib1g-dev libopenjp2-7 \
+ && apt-get install -y --no-install-recommends build-essential libjpeg-dev zlib1g-dev libopenjp2-7 curl \
  && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://ollama.com/install.sh | sh
 RUN pip install --no-cache-dir -r requirements.txt
 
 CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--NotebookApp.token=agent123"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,11 @@
 services:
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama:/root/.ollama
+
   jupyter:
     build: .
     container_name: moonshot-jupyter
@@ -9,11 +16,16 @@ services:
     environment:
       - JUPYTER_TOKEN=agent123
       - MOONSHOT_API_KEY=${MOONSHOT_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OLLAMA_HOST=http://ollama:11434
       - SHEETS_EXPORT_ENABLED=${SHEETS_EXPORT_ENABLED}
       - SHEETS_EXPORT_NAME=${SHEETS_EXPORT_NAME}
       - GCP_SERVICE_ACCOUNT_JSON=${GCP_SERVICE_ACCOUNT_JSON}
       - SHEETS_WORKSHEET_INDEX=${SHEETS_WORKSHEET_INDEX}
       - DATASET_PATH=${DATASET_PATH}
+    depends_on:
+      - ollama
     command: >
       jupyter lab
       --ip=0.0.0.0
@@ -31,13 +43,40 @@ services:
       - ./:/workspace
     environment:
       - MOONSHOT_API_KEY=${MOONSHOT_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OLLAMA_HOST=http://ollama:11434
       - SHEETS_EXPORT_ENABLED=${SHEETS_EXPORT_ENABLED}
       - SHEETS_EXPORT_NAME=${SHEETS_EXPORT_NAME}
       - GCP_SERVICE_ACCOUNT_JSON=${GCP_SERVICE_ACCOUNT_JSON}
       - SHEETS_WORKSHEET_INDEX=${SHEETS_WORKSHEET_INDEX}
       - DATASET_PATH=${DATASET_PATH}
+    depends_on:
+      - ollama
     command: >
       uvicorn src.api.main:app
       --host 0.0.0.0
       --port 8000
       --workers 2
+
+  cli:
+    build: .
+    container_name: moonshot-cli
+    volumes:
+      - ./:/workspace
+    environment:
+      - MOONSHOT_API_KEY=${MOONSHOT_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OLLAMA_HOST=http://ollama:11434
+      - SHEETS_EXPORT_ENABLED=${SHEETS_EXPORT_ENABLED}
+      - SHEETS_EXPORT_NAME=${SHEETS_EXPORT_NAME}
+      - GCP_SERVICE_ACCOUNT_JSON=${GCP_SERVICE_ACCOUNT_JSON}
+      - SHEETS_WORKSHEET_INDEX=${SHEETS_WORKSHEET_INDEX}
+      - DATASET_PATH=${DATASET_PATH}
+    depends_on:
+      - ollama
+    entrypoint: ["python", "-m", "src.cli"]
+
+volumes:
+  ollama:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 langgraph>=0.2.0
 langchain-core>=0.2.0
 langchain-openai>=0.1.0
+langchain-anthropic>=0.1.0
+langchain-ollama>=0.1.0
 jupyterlab>=4.0.0
 pymupdf>=1.23.0
 ipywidgets>=8.0.0

--- a/src/config.py
+++ b/src/config.py
@@ -1,11 +1,25 @@
 import os
 from langchain_openai import ChatOpenAI
+from langchain_anthropic import ChatAnthropic
+from langchain_ollama import ChatOllama
 
-# This configuration sets up the language model for the Moonshot POC.
-llm = ChatOpenAI(
-    base_url="https://api.moonshot.cn/v1",
-    api_key=os.getenv("MOONSHOT_API_KEY"),
-    model="kimi-k2-instruct",
-    temperature=0.7,
-    max_tokens=2000,
-)
+
+def get_llm(provider: str, model: str):
+    """Return an LLM client for the given provider and model."""
+    provider = provider.lower()
+    if provider == "openai":
+        return ChatOpenAI(api_key=os.getenv("OPENAI_API_KEY"), model=model)
+    if provider == "anthropic":
+        return ChatAnthropic(api_key=os.getenv("ANTHROPIC_API_KEY"), model=model)
+    if provider == "kimi":
+        return ChatOpenAI(
+            base_url="https://api.moonshot.cn/v1",
+            api_key=os.getenv("MOONSHOT_API_KEY"),
+            model=model,
+            temperature=0.7,
+            max_tokens=2000,
+        )
+    if provider == "ollama":
+        base_url = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+        return ChatOllama(model=model, base_url=base_url)
+    raise ValueError(f"Unsupported provider: {provider}")

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -7,7 +7,6 @@ from src.agents import (
     SecurityAgent, DevOpsAgent, PerformanceAgent, DataAgent, UXAgent,
     DataScientistAgent
 )
-from src.config import llm
 from src.export_to_sheets import export_results_to_sheets
 
 
@@ -21,12 +20,15 @@ class VerboseOrchestrator:
 
     def __init__(
         self,
+        llm,
         on_log: Callable[[str, str, str], None] | None = None,
     ) -> None:
         """Create a new orchestrator.
 
+        :param llm: LLM client to use for all agents.
         :param on_log: Optional callback to receive (agent_name, prompt, response) events.
         """
+        self.llm = llm
         self.on_log = on_log
         # Base LLM-driven agents
         self.agents: Dict[str, Any] = {
@@ -52,7 +54,7 @@ class VerboseOrchestrator:
             prompt = agent.build_prompt({"description": description})
             if self.on_log:
                 self.on_log(agent.name, prompt, "🔄 calling LLM …")
-            resp = llm.invoke(prompt).content
+            resp = self.llm.invoke(prompt).content
             if self.on_log:
                 self.on_log(agent.name, prompt, resp)
             try:


### PR DESCRIPTION
## Summary
- allow choosing local Ollama or cloud (OpenAI, Anthropic, Kimi) models at runtime
- accept llm client in orchestrator and API
- containerize CLI with optional Ollama service
- document new model options and Docker workflow

## Testing
- `python -m py_compile src/config.py src/orchestrator.py src/cli.py src/api/main.py`
- `pip install langchain-anthropic langchain-ollama`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32a15a7d48322a6e6018352e22470