### PR TITLE
feat: add AI coding agent and bump version to v0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# Moonshot Alpha v0.4
+# Moonshot Alpha v0.5
 
 Moonshot Alpha is a modular, multi‑agent framework for **planning and estimating complex software projects**.  It combines conversational Large Language Model (LLM) prompts to produce actionable **architectural plans**, **project timelines**, **cost estimates**, **security recommendations**, and more.  The goal of this release is to provide a ready‑to‑run reference implementation that can be run locally or in Docker for experimentation, prototyping and education.
 
-**What’s new in v0.4:** `.xls` export replacing Google Sheets, up to 100 retries per agent with human intervention prompts after 75 attempts, and general robustness improvements.
+**What’s new in v0.5:** Added an AI Coding agent to estimate features suitable for delegation to automated code generation, and general robustness improvements.
 
 ## Features
 
-* **Multi‑agent orchestration** – Runs nine LLM‑driven agents in parallel to produce a holistic project plan.  Each agent returns structured JSON for easy integration.
+* **Multi‑agent orchestration** – Runs ten LLM‑driven agents in parallel to produce a holistic project plan.  Each agent returns structured JSON for easy integration.
 * **Cross‑platform CLI** – Script for running all agents on a project description (`cli.py`).  Prompts for the desired LLM and prints colourised logs to the terminal.
 * **REST API** – A FastAPI service exposes endpoints for health checks, listing agents, running the orchestrator and (optionally) exporting results to an Excel `.xls` file.
 * **SaaS Web UI** – A simple front‑end served from the API at `/ui`.  Users provide a project description and run the multi‑agent orchestrator directly from the browser.  The UI includes Google authentication via Supabase, can export results to XLS and displays the latest predictions for each user.
 * **Supabase persistence (optional)** – When configured, results are **persisted per user** to a Supabase table after each run.  Users authenticate using Google OAuth via Supabase; the API verifies their JSON Web Token (JWT) and stores the description, user ID and JSON results in a `project_runs` table.  The endpoint (`/projects/latest`) returns the most recent prediction for each description for the authenticated user.
 * **Dockerised deployment** – A `Dockerfile` and `docker-compose.yml` build reproducible images for the CLI/Jupyter (port 8888), API (port 8000) and Ollama model server.  No local Python installation is required.
+* **AI coding delegation analysis** – An AICoding agent identifies features that can be automated and estimates potential AI coverage.
 
 Additional role descriptions and AI delegation guidelines are available in `docs/human_resources.md`.
 
@@ -44,7 +45,8 @@ moonshot-poc-main/
 │   │   ├── performance_agent.py
 │   │   ├── data_agent.py
 │   │   ├── ux_agent.py
-│   │   └── data_scientist_agent.py
+│   │   ├── data_scientist_agent.py
+│   │   └── ai_coding_agent.py
 ├── cli.py               # Run all agents on a project description (PDF input)
 ├── export_to_excel.py  # Utility to flatten and export results as `.xls`
 ├── orchestrator.py      # VerboseOrchestrator coordinating all agents
@@ -190,7 +192,7 @@ curl -s http://localhost:8000/health
 
 ```bash
 curl -s http://localhost:8000/agents
-# → ["architect","pm","cost","security","devops","performance","data","ux","datasci"]
+# → ["architect","pm","cost","security","devops","performance","data","ux","datasci","aicoding"]
 ```
 
 ### Run All Agents

--- a/docs/human_resources.md
+++ b/docs/human_resources.md
@@ -13,6 +13,7 @@ This document outlines the human roles involved in the Moonshot project and high
 - **Data Engineer** – prepares data pipelines and storage strategies.
 - **UX Designer** – crafts user flows and interface guidelines.
 - **Data Scientist** – performs exploratory analysis and modelling.
+- **AI Coding Analyst** – identifies features suitable for AI automation.
 
 ## AI‑Delegable Work
 
@@ -24,3 +25,7 @@ According to SWE benchmark studies, many routine software engineering tasks can 
 - Refactoring suggestions and static analysis for existing modules.
 
 Critical architectural decisions, security reviews and final approvals should remain with human experts, but repetitive or well‑bounded tasks can be offloaded to the agents or other AI tools.
+
+## Estimated AI-Delegable Features
+
+Experience suggests roughly 30–50% of common features can be drafted by AI systems. Typical candidates include authentication modules, CRUD endpoints, test scaffolding, documentation templates, and data pipeline scaffolding.

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -10,3 +10,4 @@ from .performance_agent import PerformanceAgent
 from .data_agent import DataAgent
 from .ux_agent import UXAgent
 from .data_scientist_agent import DataScientistAgent
+from .ai_coding_agent import AICodingAgent

--- a/src/agents/ai_coding_agent.py
+++ b/src/agents/ai_coding_agent.py
@@ -1,0 +1,31 @@
+import json
+import sys
+sys.path.append('/workspace')
+from .base_agent import BaseAgent
+from src.config import llm
+
+
+class AICodingAgent(BaseAgent):
+    """Assess which features can be delegated to AI-generated code."""
+
+    def __init__(self):
+        super().__init__("AICoding")
+
+    def build_prompt(self, data):
+        return """
+You are an AI coding assistant evaluating a software project.
+Project: {0}
+
+List major features that could be delegated to AI code generation. For each feature provide an estimated percentage of the implementation that AI can handle.
+Return JSON:
+{
+  "delegable_features": [
+    {"feature": "Authentication", "ai_coverage_percent": 60, "notes": "Boilerplate and CRUD"}
+  ]
+}
+""".format(data.get('description', ''))
+
+    def analyze(self, data):
+        prompt = self.build_prompt(data)
+        resp = llm.invoke(prompt).content
+        return {"agent": self.name, **json.loads(resp or "{}")}

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -141,7 +141,7 @@ def health() -> Dict[str, str]:
 def list_agents():
     return [
         "architect", "pm", "cost", "security",
-        "devops", "performance", "data", "ux", "datasci",
+        "devops", "performance", "data", "ux", "datasci", "aicoding",
     ]
 
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,4 +1,4 @@
-"""Command-line interface for Moonshot POC v0.4.
+"""Command-line interface for Moonshot POC v0.5.
 
 This script reads a PDF file containing a high-level project description, runs all
 registered agents via the VerboseOrchestrator, and prints verbose logs with
@@ -54,6 +54,7 @@ COLOR_MAP: Dict[str, str] = {
     "Data": Fore.LIGHTYELLOW_EX,
     "UX": Fore.LIGHTWHITE_EX,
     "DataScientist": Fore.LIGHTCYAN_EX,
+    "AICoding": Fore.LIGHTGREEN_EX,
 }
 
 

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict, Any
 from src.agents import (
     ArchitectAgent, ProjectManagerAgent, CostEstimatorAgent,
     SecurityAgent, DevOpsAgent, PerformanceAgent, DataAgent, UXAgent,
-    DataScientistAgent,
+    DataScientistAgent, AICodingAgent,
 )
 from src.export_to_excel import export_results_to_xls
 
@@ -41,6 +41,7 @@ class VerboseOrchestrator:
             "data":        DataAgent(),
             "ux":          UXAgent(),
             "datasci":     DataScientistAgent(),
+            "aicoding":    AICodingAgent(),
         }
 
         self._xls_enabled = os.getenv("XLS_EXPORT_ENABLED", "false").lower() == "true"


### PR DESCRIPTION
## Summary
- add AICoding agent to estimate delegable features
- document AI delegation and bump docs to version 0.5
- wire new agent into orchestrator, API, and CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a39d8658ec832282c9a22a280a437c