### PR TITLE
feat: add card UI with agent selection and progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Moonshot Alpha v0.5
+# Moonshot Alpha v0.6
 
 Moonshot Alpha is a modular, multi‑agent framework for **planning and estimating complex software projects**.  It combines conversational Large Language Model (LLM) prompts to produce actionable **architectural plans**, **project timelines**, **cost estimates**, **security recommendations**, and more.  The goal of this release is to provide a ready‑to‑run reference implementation that can be run locally or in Docker for experimentation, prototyping and education.
 
-**What’s new in v0.5:** Added an AI Coding agent to estimate features suitable for delegation to automated code generation, and general robustness improvements.
+**What’s new in v0.6:** Refreshed SaaS UI using Tailwind and shadcn-style cards, selectable agents with per-agent progress bars, and version bump.
 
 ## Features
 
 * **Multi‑agent orchestration** – Runs ten LLM‑driven agents in parallel to produce a holistic project plan.  Each agent returns structured JSON for easy integration.
 * **Cross‑platform CLI** – Script for running all agents on a project description (`cli.py`).  Prompts for the desired LLM and prints colourised logs to the terminal.
 * **REST API** – A FastAPI service exposes endpoints for health checks, listing agents, running the orchestrator and (optionally) exporting results to an Excel `.xls` file.
-* **SaaS Web UI** – A simple front‑end served from the API at `/ui`.  Users provide a project description and run the multi‑agent orchestrator directly from the browser.  The UI includes Google authentication via Supabase, can export results to XLS and displays the latest predictions for each user.
+* **SaaS Web UI** – A Tailwind-styled front‑end served from the API at `/ui`. Users can select which agents to run, watch per‑agent progress bars, authenticate via Google (Supabase), export to XLS and view their latest predictions.
 * **Supabase persistence (optional)** – When configured, results are **persisted per user** to a Supabase table after each run.  Users authenticate using Google OAuth via Supabase; the API verifies their JSON Web Token (JWT) and stores the description, user ID and JSON results in a `project_runs` table.  The endpoint (`/projects/latest`) returns the most recent prediction for each description for the authenticated user.
 * **Dockerised deployment** – A `Dockerfile` and `docker-compose.yml` build reproducible images for the CLI/Jupyter (port 8888), API (port 8000) and Ollama model server.  No local Python installation is required.
 * **AI coding delegation analysis** – An AICoding agent identifies features that can be automated and estimates potential AI coverage.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,73 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Moonshot POC SaaS</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 2rem;
-            max-width: 800px;
-        }
-        h1, h2 {
-            margin-top: 1.5rem;
-        }
-        label {
-            display: block;
-            margin-top: 1rem;
-        }
-        input[type="text"], textarea, select {
-            width: 100%;
-            padding: 0.5rem;
-            margin-top: 0.25rem;
-            box-sizing: border-box;
-        }
-        button {
-            margin-top: 1rem;
-            padding: 0.5rem 1rem;
-            cursor: pointer;
-        }
-        pre {
-            background: #f5f5f5;
-            border: 1px solid #ddd;
-            padding: 1rem;
-            overflow-x: auto;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-        }
-        .message {
-            margin-top: 0.5rem;
-            font-size: 0.9rem;
-        }
-    </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Moonshot POC SaaS</title>
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <!-- Authentication bar -->
-    <div id="auth" style="margin-bottom: 1rem;">
-        <span id="auth-info"></span>
-        <button id="login-btn">Accedi con Google</button>
-        <button id="logout-btn" style="display:none;">Esci</button>
+<body class="bg-gray-50">
+  <div class="max-w-3xl mx-auto p-6 space-y-6">
+    <div id="auth" class="flex justify-end items-center space-x-4">
+      <span id="auth-info" class="text-sm text-gray-700"></span>
+      <button id="login-btn" class="px-4 py-2 bg-blue-600 text-white rounded shadow">Accedi con Google</button>
+      <button id="logout-btn" class="px-4 py-2 bg-gray-300 rounded hidden">Esci</button>
     </div>
 
-    <h1>Moonshot POC SaaS</h1>
-    <p>Provide a project description and run the multi‑agent orchestrator. Results will appear below.</p>
-
-    <div id="app-content" style="display:none;">
-        <h2>Run Project</h2>
-        <label for="description">Project description</label>
-        <textarea id="description" rows="6" placeholder="Describe your project here..."></textarea>
-        <label><input type="checkbox" id="export-enabled"> Export to XLS</label>
-        <button id="run-btn">Run Agents</button>
-        <div id="run-msg" class="message"></div>
-        <pre id="results"></pre>
-
-        <h2>Recent Runs</h2>
-        <pre id="history"></pre>
+    <div>
+      <h1 class="text-2xl font-bold">Moonshot POC SaaS</h1>
+      <p class="text-gray-600">Provide a project description and run the multi‑agent orchestrator. Results will appear below.</p>
     </div>
 
-    <!-- Supabase client library -->
-    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
-    <script src="main.js"></script>
+    <div id="app-content" class="hidden space-y-6">
+      <div class="bg-white p-6 rounded-lg shadow">
+        <h2 class="text-xl font-semibold mb-4">Run Project</h2>
+        <label for="description" class="block text-sm font-medium">Project description</label>
+        <textarea id="description" rows="6" placeholder="Describe your project here..." class="mt-1 w-full border rounded p-2"></textarea>
+
+        <div id="agent-list" class="mt-4 grid grid-cols-2 gap-2"></div>
+
+        <label class="flex items-center space-x-2 mt-4">
+          <input type="checkbox" id="export-enabled" class="h-4 w-4">
+          <span>Export to XLS</span>
+        </label>
+
+        <button id="run-btn" class="mt-4 px-4 py-2 bg-green-600 text-white rounded shadow">Run Agents</button>
+        <div id="run-msg" class="text-sm mt-2"></div>
+      </div>
+
+      <div id="progress-container" class="space-y-4"></div>
+
+      <pre id="results" class="bg-gray-100 p-4 rounded-lg shadow text-sm whitespace-pre-wrap"></pre>
+
+      <div class="bg-white p-6 rounded-lg shadow">
+        <h2 class="text-xl font-semibold mb-4">Recent Runs</h2>
+        <pre id="history" class="bg-gray-100 p-4 rounded-lg text-sm whitespace-pre-wrap"></pre>
+      </div>
+    </div>
+  </div>
+
+  <!-- Supabase client library -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+  <script src="main.js"></script>
 </body>
 </html>

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -126,6 +126,10 @@ class RunRequest(BaseModel):
         None,
         description="Override the XLS export flag for this run only."
     )
+    agents: Optional[List[str]] = Field(
+        None,
+        description="Subset of agents to run. Runs all if omitted.",
+    )
 
 
 class RunResponse(BaseModel):
@@ -165,7 +169,7 @@ def run(req: RunRequest, authorization: Optional[str] = Header(None)) -> RunResp
         orch._xls_enabled = bool(req.export_enabled)
 
     try:
-        results = orch.run(req.description)
+        results = orch.run(req.description, req.agents)
         _persist_run(user, req.description, results)
         return RunResponse(results=results)
     except Exception as e:

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,4 +1,4 @@
-"""Command-line interface for Moonshot POC v0.5.
+"""Command-line interface for Moonshot POC v0.6.
 
 This script reads a PDF file containing a high-level project description, runs all
 registered agents via the VerboseOrchestrator, and prints verbose logs with

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -49,9 +49,11 @@ class VerboseOrchestrator:
         self.max_retries = int(os.getenv("AGENT_MAX_RETRIES", "100"))
         self._intervention_threshold = int(self.max_retries * 0.75)
 
-    def run(self, description: str) -> Dict[str, Any]:
+    def run(self, description: str, agents_to_run: list[str] | None = None) -> Dict[str, Any]:
         results: Dict[str, Any] = {}
         for key, agent in self.agents.items():
+            if agents_to_run and key not in agents_to_run:
+                continue
             prompt = agent.build_prompt({"description": description})
             attempt = 0
             while attempt < self.max_retries:


### PR DESCRIPTION
## Summary
- style SaaS frontend with Tailwind card layout and per-agent progress bars
- allow selecting which agents run and support this in API/orchestrator
- bump project version to 0.6 and update docs

## Testing
- `node --check frontend/main.js`
- `python -m py_compile src/api/main.py src/orchestrator.py src/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3eca8ca3083228b4bdc6030b8c76d