### PR TITLE
feat: add agent selection toggles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,7 +25,11 @@
         <label for="description" class="block text-sm font-medium">Project description</label>
         <textarea id="description" rows="6" placeholder="Describe your project here..." class="mt-1 w-full border rounded p-2"></textarea>
 
-        <div id="agent-list" class="mt-4 grid grid-cols-2 gap-2"></div>
+        <div class="mt-4">
+          <label class="block text-sm font-medium">Agents</label>
+          <p class="text-gray-600 text-sm">Select which agents to run:</p>
+          <div id="agent-list" class="mt-2 grid grid-cols-2 gap-2"></div>
+        </div>
 
         <label class="flex items-center space-x-2 mt-4">
           <input type="checkbox" id="export-enabled" class="h-4 w-4">

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -28,8 +28,12 @@ async function fetchAgents() {
         const container = document.getElementById('agent-list');
         agents.forEach(agent => {
             const label = document.createElement('label');
-            label.className = 'flex items-center space-x-2';
-            label.innerHTML = `<input type="checkbox" value="${agent}" class="agent-checkbox" checked><span class="capitalize">${agent}</span>`;
+            label.className = 'flex items-center space-x-2 cursor-pointer';
+            label.innerHTML =
+                `<input type="checkbox" value="${agent}" class="sr-only peer agent-checkbox" checked>` +
+                `<div class="w-10 h-6 bg-gray-200 rounded-full peer-checked:bg-blue-600 relative transition-colors">` +
+                `<div class="absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform peer-checked:translate-x-4"></div>` +
+                `</div><span class="capitalize">${agent}</span>`;
             container.appendChild(label);
         });
     } catch (err) {


### PR DESCRIPTION
## Summary
- add labeled agent selection area to run view
- render fetched agents as toggle switches before running

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3f1a07ec483229c934765e162cda1