### PR TITLE
feat: add technical agent and PDF export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Moonshot Alpha v0.6.1
+# Moonshot Alpha v0.6.2
 
 Moonshot Alpha is a modular, multi‑agent framework for **planning and estimating complex software projects**.  It combines conversational Large Language Model (LLM) prompts to produce actionable **architectural plans**, **project timelines**, **cost estimates**, **security recommendations**, and more.  The goal of this release is to provide a ready‑to‑run reference implementation that can be run locally or in Docker for experimentation, prototyping and education.
 
-**What’s new in v0.6.1:** Added CLI flag to run a subset of agents to control cost, refreshed SaaS UI using Tailwind and shadcn-style cards, selectable agents with per-agent progress bars, and version bump.
+**What’s new in v0.6.2:** Added TechnicalAgent to generate PDF technical documentation after estimation and updated versioning.
 
 ## Features
 
-* **Multi‑agent orchestration** – Runs up to ten LLM‑driven agents in parallel to produce a holistic project plan. Agents can be batched or disabled to control cost, and each returns structured JSON for easy integration.
+* **Multi‑agent orchestration** – Runs up to eleven LLM‑driven agents in parallel to produce a holistic project plan. Agents can be batched or disabled to control cost, and each returns structured JSON for easy integration.
 * **Cross‑platform CLI** – Script for running agents on a project description (`cli.py`). Prompts for the desired LLM, prints colourised logs to the terminal, and supports selecting a subset of agents via `--agents`.
 * **REST API** – A FastAPI service exposes endpoints for health checks, listing agents, running the orchestrator and (optionally) exporting results to an Excel `.xls` file.
 * **SaaS Web UI** – A Tailwind-styled front‑end served from the API at `/ui`. Users can select which agents to run, watch per‑agent progress bars, authenticate via Google (Supabase), export to XLS and view their latest predictions.
@@ -46,9 +46,11 @@ moonshot-poc-main/
 │   │   ├── data_agent.py
 │   │   ├── ux_agent.py
 │   │   ├── data_scientist_agent.py
-│   │   └── ai_coding_agent.py
+│   │   ├── ai_coding_agent.py
+│   │   └── technical_agent.py
 ├── cli.py               # Run selected agents on a project description (PDF input)
 ├── export_to_excel.py  # Utility to flatten and export results as `.xls`
+├── export_to_pdf.py    # Utility to save technical documentation as PDF
 ├── orchestrator.py      # VerboseOrchestrator coordinating all agents
 └── config.py            # Factory to create LLM clients for Ollama or cloud providers
 ```
@@ -195,7 +197,7 @@ curl -s http://localhost:8000/health
 
 ```bash
 curl -s http://localhost:8000/agents
-# → ["architect","pm","cost","security","devops","performance","data","ux","datasci","aicoding"]
+# → ["architect","pm","cost","security","devops","performance","data","ux","datasci","aicoding","technical"]
 ```
 
 ### Run All Agents

--- a/docs/Technical Doc.pdf
+++ b/docs/Technical Doc.pdf
@@ -1,0 +1,71 @@
+%PDF-1.3
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/Contents 4 0 R>>
+endobj
+4 0 obj
+<</Filter /FlateDecode /Length 142>>
+stream
+xU
+0E>uIK	{Di)ҷ7"n9ƾ⬕xT+b' j9-F0 UˤY)qr`tM2cb98F1ɇC쫋cN}	^7<e>|@5
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+/MediaBox [0 0 595.28 841.89]
+>>
+endobj
+5 0 obj
+<</Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+6 0 obj
+<<
+/Producer (PyFPDF 1.7.2 http://pyfpdf.googlecode.com/)
+/CreationDate (D:20250819060920)
+>>
+endobj
+7 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000299 00000 n 
+0000000482 00000 n 
+0000000009 00000 n 
+0000000087 00000 n 
+0000000386 00000 n 
+0000000586 00000 n 
+0000000695 00000 n 
+trailer
+<<
+/Size 8
+/Root 7 0 R
+/Info 6 0 R
+>>
+startxref
+798
+%%EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,6 @@ aiofiles>=23.0.0
 
 # Supabase client for persistence and authentication
 supabase>=1.0.0
+
+# PDF generation
+fpdf>=1.7.2

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -11,3 +11,4 @@ from .data_agent import DataAgent
 from .ux_agent import UXAgent
 from .data_scientist_agent import DataScientistAgent
 from .ai_coding_agent import AICodingAgent
+from .technical_agent import TechnicalAgent

--- a/src/agents/technical_agent.py
+++ b/src/agents/technical_agent.py
@@ -1,0 +1,30 @@
+import json
+
+from .base_agent import BaseAgent
+from src.config import llm
+
+
+class TechnicalAgent(BaseAgent):
+    """Generate technical documentation for the project."""
+
+    def __init__(self) -> None:
+        super().__init__("TechnicalWriter")
+
+    def build_prompt(self, data: dict) -> str:
+        description = data.get("description", "")
+        return (
+            "You are a senior technical writer.\n"
+            "Draft a technical documentation summarizing the project's goals, "
+            "architecture, and key technology choices.\n"
+            "Return JSON with a single key 'documentation' containing the "
+            "documentation as markdown text.\n"
+            f"PROJECT_DESCRIPTION: {description}"
+        )
+
+    def analyze(self, data: dict) -> dict:
+        prompt = self.build_prompt(data)
+        resp = llm.invoke(prompt).content
+        try:
+            return json.loads(resp or "{}")
+        except json.JSONDecodeError:
+            return {"documentation": resp}

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,4 +1,4 @@
-"""Command-line interface for Moonshot POC v0.6.1.
+"""Command-line interface for Moonshot POC v0.6.2.
 
 This script reads a PDF file containing a high-level project description, runs
 selected agents via the ``VerboseOrchestrator`` and prints verbose logs with

--- a/src/export_to_pdf.py
+++ b/src/export_to_pdf.py
@@ -1,0 +1,12 @@
+from fpdf import FPDF
+
+
+def export_text_to_pdf(text: str, file_path: str) -> None:
+    """Export plain text to a simple PDF file."""
+    pdf = FPDF()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    for line in text.splitlines():
+        pdf.multi_cell(0, 10, line)
+    pdf.output(file_path)

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -5,9 +5,10 @@ from typing import Callable, Dict, Any
 from src.agents import (
     ArchitectAgent, ProjectManagerAgent, CostEstimatorAgent,
     SecurityAgent, DevOpsAgent, PerformanceAgent, DataAgent, UXAgent,
-    DataScientistAgent, AICodingAgent,
+    DataScientistAgent, AICodingAgent, TechnicalAgent,
 )
 from src.export_to_excel import export_results_to_xls
+from src.export_to_pdf import export_text_to_pdf
 
 
 class VerboseOrchestrator:
@@ -42,10 +43,12 @@ class VerboseOrchestrator:
             "ux":          UXAgent(),
             "datasci":     DataScientistAgent(),
             "aicoding":    AICodingAgent(),
+            "technical":   TechnicalAgent(),
         }
 
         self._xls_enabled = os.getenv("XLS_EXPORT_ENABLED", "false").lower() == "true"
         self._xls_path = os.getenv("XLS_EXPORT_PATH", "/workspace/results.xls")
+        self._pdf_path = os.getenv("TECH_DOC_PATH", "/workspace/Technical Doc.pdf")
         self.max_retries = int(os.getenv("AGENT_MAX_RETRIES", "100"))
         self._intervention_threshold = int(self.max_retries * 0.75)
 
@@ -92,5 +95,15 @@ class VerboseOrchestrator:
             except Exception as e:
                 if self.on_log:
                     self.on_log("Exporter", f"File={self._xls_path}", f"❌ Export failed: {e}")
+
+        doc = results.get("technical", {}).get("documentation")
+        if doc:
+            try:
+                export_text_to_pdf(doc, self._pdf_path)
+                if self.on_log:
+                    self.on_log("Exporter", f"File={self._pdf_path}", "✅ Exported technical doc")
+            except Exception as e:
+                if self.on_log:
+                    self.on_log("Exporter", f"File={self._pdf_path}", f"❌ Technical doc export failed: {e}")
 
         return results


### PR DESCRIPTION
## Summary
- add TechnicalAgent to generate project documentation
- export technical documentation to PDF after orchestrator run
- bump version to v0.6.2 and update README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a4140ef4e88322ac55b83b15f0763f