### PR TITLE
Add optional documentation agent and version bump to 0.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Moonshot Alpha v0.6.2
+# Moonshot Alpha v0.6.4
 
 Moonshot Alpha is a modular, multi‑agent framework for **planning and estimating complex software projects**.  It combines conversational Large Language Model (LLM) prompts to produce actionable **architectural plans**, **project timelines**, **cost estimates**, **security recommendations**, and more.  The goal of this release is to provide a ready‑to‑run reference implementation that can be run locally or in Docker for experimentation, prototyping and education.
 
-**What’s new in v0.6.2:** Added TechnicalAgent to generate PDF technical documentation after estimation and updated versioning.
+**What’s new in v0.6.4:** Added optional DocumentationAgent for end‑of‑project technical documentation, updated UI and bumped version.
 
 ## Features
 
-* **Multi‑agent orchestration** – Runs up to eleven LLM‑driven agents in parallel to produce a holistic project plan. Agents can be batched or disabled to control cost, and each returns structured JSON for easy integration.
+* **Multi‑agent orchestration** – Runs up to twelve LLM‑driven agents in parallel, including an optional documentation agent, to produce a holistic project plan. Agents can be batched or disabled to control cost, and each returns structured JSON for easy integration.
 * **Cross‑platform CLI** – Script for running agents on a project description (`cli.py`). Prompts for the desired LLM, prints colourised logs to the terminal, and supports selecting a subset of agents via `--agents`.
 * **REST API** – A FastAPI service exposes endpoints for health checks, listing agents, running the orchestrator and (optionally) exporting results to an Excel `.xls` file.
 * **SaaS Web UI** – A Tailwind-styled front‑end served from the API at `/ui`. Users can select which agents to run, watch per‑agent progress bars, authenticate via Google (Supabase), export to XLS and view their latest predictions.
@@ -47,7 +47,8 @@ moonshot-poc-main/
 │   │   ├── ux_agent.py
 │   │   ├── data_scientist_agent.py
 │   │   ├── ai_coding_agent.py
-│   │   └── technical_agent.py
+│   │   ├── technical_agent.py
+│   │   └── documentation_agent.py
 ├── cli.py               # Run selected agents on a project description (PDF input)
 ├── export_to_excel.py  # Utility to flatten and export results as `.xls`
 ├── export_to_pdf.py    # Utility to save technical documentation as PDF

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,7 +27,7 @@
 
         <div class="mt-4">
           <label class="block text-sm font-medium">Agents</label>
-          <p class="text-gray-600 text-sm">Select which agents to run:</p>
+          <p class="text-gray-600 text-sm">Select which agents to run (documentation runs last and is optional):</p>
           <div id="agent-list" class="mt-2 grid grid-cols-2 gap-2"></div>
         </div>
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -29,11 +29,12 @@ async function fetchAgents() {
         agents.forEach(agent => {
             const label = document.createElement('label');
             label.className = 'flex items-center space-x-2 cursor-pointer';
+            const checked = agent === 'documentation' ? '' : 'checked';
             label.innerHTML =
-                `<input type="checkbox" value="${agent}" class="sr-only peer agent-checkbox" checked>` +
-                `<div class="w-10 h-6 bg-gray-200 rounded-full peer-checked:bg-blue-600 relative transition-colors">` +
-                `<div class="absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform peer-checked:translate-x-4"></div>` +
-                `</div><span class="capitalize">${agent}</span>`;
+                `<input type="checkbox" value="${agent}" class="sr-only peer agent-checkbox" ${checked}>` +
+                `<div class=\"w-10 h-6 bg-gray-200 rounded-full peer-checked:bg-blue-600 relative transition-colors\">` +
+                `<div class=\"absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform peer-checked:translate-x-4\"></div>` +
+                `</div><span class=\"capitalize\">${agent}</span>`;
             container.appendChild(label);
         });
     } catch (err) {

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -12,3 +12,4 @@ from .ux_agent import UXAgent
 from .data_scientist_agent import DataScientistAgent
 from .ai_coding_agent import AICodingAgent
 from .technical_agent import TechnicalAgent
+from .documentation_agent import DocumentationAgent

--- a/src/agents/documentation_agent.py
+++ b/src/agents/documentation_agent.py
@@ -1,0 +1,32 @@
+import json
+
+from .base_agent import BaseAgent
+from src.config import llm
+
+
+class DocumentationAgent(BaseAgent):
+    """Compile final technical documentation from previous agent outputs."""
+
+    def __init__(self) -> None:
+        super().__init__("Documentation")
+
+    def build_prompt(self, data: dict) -> str:
+        description = data.get("description", "")
+        results = data.get("results", {})
+        return (
+            "You are a senior technical writer.\n"
+            "Create final technical documentation based on the project description "
+            "and the structured results from prior analysis.\n"
+            "Return JSON with key 'documentation' containing markdown.\n"
+            f"PROJECT_DESCRIPTION: {description}\n"
+            f"AGENT_RESULTS: {json.dumps(results)}"
+        )
+
+    def analyze(self, data: dict) -> dict:
+        prompt = self.build_prompt(data)
+        resp = llm.invoke(prompt).content
+        try:
+            return json.loads(resp or "{}")
+        except json.JSONDecodeError:
+            return {"documentation": resp}
+

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -146,6 +146,7 @@ def list_agents():
     return [
         "architect", "pm", "cost", "security",
         "devops", "performance", "data", "ux", "datasci", "aicoding",
+        "documentation",
     ]
 
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,4 +1,4 @@
-"""Command-line interface for Moonshot POC v0.6.2.
+"""Command-line interface for Moonshot POC v0.6.4.
 
 This script reads a PDF file containing a high-level project description, runs
 selected agents via the ``VerboseOrchestrator`` and prints verbose logs with
@@ -55,6 +55,7 @@ COLOR_MAP: Dict[str, str] = {
     "UX": Fore.LIGHTWHITE_EX,
     "DataScientist": Fore.LIGHTCYAN_EX,
     "AICoding": Fore.LIGHTGREEN_EX,
+    "Documentation": Fore.LIGHTBLUE_EX,
 }
 
 


### PR DESCRIPTION
## Summary
- add DocumentationAgent to generate final technical documentation
- run documentation agent as optional step in orchestrator and expose via API/UI
- bump version to 0.6.4 and update README/CLI

## Testing
- `python -m py_compile src/orchestrator.py src/api/main.py src/cli.py src/agents/documentation_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4193a027883228219a09bd727c9bf